### PR TITLE
Fix getting signed key and validation function

### DIFF
--- a/01-Authenticate-RS256/server.js
+++ b/01-Authenticate-RS256/server.js
@@ -82,7 +82,7 @@ server.register(jwt, err => {
     complete: true,
     // verify the access token against the
     // remote Auth0 JWKS
-    key: jwksRsa.hapiJwt2Key({
+    key: jwksRsa.hapiJwt2KeyAsync({
       cache: true,
       rateLimit: true,
       jwksRequestsPerMinute: 5,
@@ -93,7 +93,7 @@ server.register(jwt, err => {
       issuer: `https://${process.env.AUTH0_DOMAIN}/`,
       algorithms: ['RS256']
     },
-    validateFunc: validateUser
+    validate: validateUser
   });
   registerRoutes();
 });


### PR DESCRIPTION
The current example with hapi-auth-jwt2@8.6.0 results in the following errors
1. Undefined key 
> TypeError: Cannot destructure property `key` of 'undefined' or 'null' at /node_modules/hapi-auth-jwt2/lib/index.js:66

Because the method `jwkRsa.hapiJwt2Key` uses a callback to return the signed key. The async version will return the key as expected.

2. The name of the validation function has changed from `validateFunc` to `validate` see. https://github.com/dwyl/hapi-auth-jwt2/blob/master/test/complete_token.test.js#L22

# Pull Request Report

Please include a summary of the change you made with relevant motivation and context why such change has been made. Filling sections below will allow us to get your changes reviewed and merged easier. If you feel like certain section is not applicable, feel free to delete it. Thanks for co-operation! 🙏🏼

### Description

Tell us what you changed, why you did it and what additional value it will bring.

### Type of change

- [x] Bug fix (fix to an issue)
- [ ] New feature (changes to functionality)
- [ ] Big change (fix or feature that would cause existing functionality to work as expected)

### Testing

Please describe the tests that you ran to verify your changes. Provide any instructions that will allow us to reproduce it. Please also list any relevant details for your test configuration.

**Test Configuration**

* Framework version: N/A
* Language version: N/A
* Browser version: N/A

### Additional info

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings and errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
